### PR TITLE
Update lifecycle_probes.go

### DIFF
--- a/lifecycle_probes.go
+++ b/lifecycle_probes.go
@@ -58,7 +58,7 @@ func init() {
 
 	f.BoolVarP(&probeInput.SSL, "ssl", "", false, "Determines if SSL is enabled")
 	f.BoolVarP(&probeInput.Auth, "auth", "", false, "Determines if authentication is enabled")
-	f.StringVarP(&probeInput.Endpoint, "endpoint", "", "/_api/version", "Determines if SSL is enabled")
+	f.StringVarP(&probeInput.Endpoint, "endpoint", "", "/_api/version", "Endpoint (path) to call for lifecycle probe")
 	f.StringVarP(&probeInput.JWTPath, "jwt", "", k8sutil.ClusterJWTSecretVolumeMountDir, "Path to the JWT tokens")
 }
 


### PR DESCRIPTION
Fix a wrong description for the `--endpoint` option in the lifecycle probe command.